### PR TITLE
Fixed an Issue Forget to Import get_object_or_404()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Event-Reservation
+[![Django CI](https://github.com/Mamajin/Event-Reservation/actions/workflows/django.yml/badge.svg)](https://github.com/Mamajin/Event-Reservation/actions/workflows/django.yml)
+
 Welcome to the Event Reservation System! This web application allows users to create, manage, and participate in various events. 
 The project is built using Django for the backend and React for the frontend, aiming to provide a practical solution for event discovery, registration, and feedback.
 

--- a/backend/api/views/event.py
+++ b/backend/api/views/event.py
@@ -1,5 +1,5 @@
 from .schemas import EventSchema, EventResponseSchema, ErrorResponseSchema
-from .modules import JWTAuth, Organizer, HttpError, timezone, Event, HttpRequest, logger, Response, Router, List
+from .modules import JWTAuth, Organizer, HttpError, timezone, Event, HttpRequest, logger, Response, Router, List, get_object_or_404
 router = Router()
 
 


### PR DESCRIPTION
This pull request addresses a critical issue where the function get_object_or_404() was not imported in the relevant module. This oversight could lead to runtime errors when attempting to retrieve objects from the database, specifically when handling requests that require fetching specific instances of models.
## Changes Made:
- Added the missing import statement for get_object_or_404() from django.shortcuts to ensure that it is available for use in the relevant views.
- Verified that all instances where get_object_or_404() is used are functioning correctly after the import was added.

This fix ensures that the application can reliably retrieve objects from the database and handle cases where an object does not exist, improving overall stability and user experience.